### PR TITLE
Ignore type linting for now on returned np array

### DIFF
--- a/scipeds/data/engine.py
+++ b/scipeds/data/engine.py
@@ -54,7 +54,8 @@ class IPEDSQueryEngine:
             List[str]: A list of all available tables
         """
         tables = self.get_df_from_query("SHOW TABLES").iloc[:, 0].values.tolist()
-        return tables
+        # Temporary numpy typing fix - see https://github.com/numpy/numpy/issues/27944
+        return tables  # type: ignore[return-value]
 
     def get_cip_table(self) -> pd.DataFrame:
         """Get a table of every unique 2020 CIP Code


### PR DESCRIPTION
Temporary fix for an [issue](https://github.com/numpy/numpy/issues/27944) with numpy-2.0.0