### PR TITLE
Make docs build fail loudly if jupyter notebook does not run

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
               - griffe_pydantic
   - mkdocs-jupyter:
       execute: true
+      allow_errors: false
   - search
 
 watch:


### PR DESCRIPTION
Before, the notebook would just keep running - this lets us know if there's a problem when the notebook runs.