### PR TITLE
Force anonymous client use for data download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.0.4"
 dependencies = [
   "cloudpathlib[gs]",
   "duckdb",
+  "google-cloud-storage",
   "numpy",
   "pandas",
   "platformdirs",

--- a/scipeds/cli.py
+++ b/scipeds/cli.py
@@ -4,7 +4,7 @@ from shutil import rmtree
 import typer
 from cloudpathlib.exceptions import CloudPathNotExistsError
 from cloudpathlib.gs import GSClient
-from google.storage.client import Client as StorageClient
+from google.cloud.storage.client import Client as StorageClient  # type: ignore
 
 from scipeds.constants import DB_NAME, SCIPEDS_BUCKET, SCIPEDS_CACHE_DIR
 
@@ -47,8 +47,8 @@ def download_db(
         return
 
     anonymous_client = StorageClient.create_anonymous_client()
-    gs_client = GSClient(anonymous_client)
-    processed_db = gs_client.GSPath(f"gs://{SCIPEDS_BUCKET}/processed/{DB_NAME}")
+    gs_client = GSClient(storage_client=anonymous_client)
+    processed_db = gs_client.GSPath(f"gs://{SCIPEDS_BUCKET}/processed/{DB_NAME}")  # type: ignore
 
     if verbose:
         print(f"Downloading pre-processed IPEDS db to {output_path}")

--- a/scipeds/cli.py
+++ b/scipeds/cli.py
@@ -3,7 +3,8 @@ from shutil import rmtree
 
 import typer
 from cloudpathlib.exceptions import CloudPathNotExistsError
-from cloudpathlib.gs import GSPath
+from cloudpathlib.gs import GSClient
+from google.storage.client import Client as StorageClient
 
 from scipeds.constants import DB_NAME, SCIPEDS_BUCKET, SCIPEDS_CACHE_DIR
 
@@ -45,7 +46,9 @@ def download_db(
         )
         return
 
-    processed_db = GSPath(f"gs://{SCIPEDS_BUCKET}/processed/{DB_NAME}")
+    anonymous_client = StorageClient.create_anonymous_client()
+    gs_client = GSClient(anonymous_client)
+    processed_db = gs_client.GSPath(f"gs://{SCIPEDS_BUCKET}/processed/{DB_NAME}")
 
     if verbose:
         print(f"Downloading pre-processed IPEDS db to {output_path}")


### PR DESCRIPTION
Downloading data on Colab fails due to a cloudpathlib issue with Google auth on Colab. This PR forces the use of an anonymous client to download the publicly available data, which bypasses the issue.