### PR TITLE
Explicitly index by integer to avoid future warning

### DIFF
--- a/scipeds/utils.py
+++ b/scipeds/utils.py
@@ -28,7 +28,7 @@ def forward_fold_transform(values: npt.NDArray | pd.Series) -> npt.NDArray:
     """
     values = values.copy()
     null_idx = np.flatnonzero(values <= 0)
-    values[null_idx] = np.nan
+    values.iloc[null_idx] = np.nan
     transformed = np.array(list(map(lambda x: 1 - np.divide(1, x) if x <= 1 else x - 1, values)))
     transformed[null_idx] = -np.inf
     return transformed

--- a/scipeds/utils.py
+++ b/scipeds/utils.py
@@ -26,9 +26,9 @@ def forward_fold_transform(values: npt.NDArray | pd.Series) -> npt.NDArray:
 
     Note that the numeric values on a linear fold scale differ from the labeled values by 1.
     """
-    values = values.copy()
+    values = np.asarray(values).copy()
     null_idx = np.flatnonzero(values <= 0)
-    values.iloc[null_idx] = np.nan
+    values[null_idx] = np.nan
     transformed = np.array(list(map(lambda x: 1 - np.divide(1, x) if x <= 1 else x - 1, values)))
     transformed[null_idx] = -np.inf
     return transformed


### PR DESCRIPTION
Newer python/pandas gives a future warning on this line:

```
.../lib/python3.10/site-packages/scipeds/utils.py:31): FutureWarning: Series.__setitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To set a value by position, use `ser.iloc[pos] = value`
  values[null_idx] = np.nan
```